### PR TITLE
Reconnect when connection drops

### DIFF
--- a/internal/app/streamer.go
+++ b/internal/app/streamer.go
@@ -96,6 +96,7 @@ func (b *BasinStreamer) sign(tx basincapnp.Tx) ([]byte, error) {
 	return signature, nil
 }
 
+// TODO: Add exponential backoff on reconnect
 func (b *BasinStreamer) push(ctx context.Context, table string, tx basincapnp.Tx, signature []byte) error {
 	if err := b.provider.Push(ctx, b.namespace, table, tx, signature); exc.IsType(err, exc.Disconnected) {
 		slog.Info("reconnecting")

--- a/internal/app/streamer_test.go
+++ b/internal/app/streamer_test.go
@@ -100,6 +100,13 @@ type basinProviderMock struct {
 	owner map[string]string
 }
 
+func (bp *basinProviderMock) Create(
+	_ context.Context, ns string, _ string, _ basincapnp.Schema, owner common.Address,
+) error {
+	bp.owner[ns] = owner.Hex()
+	return nil
+}
+
 func (bp *basinProviderMock) Push(
 	_ context.Context, _ string, _ string, tx basincapnp.Tx, signature []byte,
 ) error {
@@ -111,9 +118,6 @@ func (bp *basinProviderMock) Push(
 	return nil
 }
 
-func (bp *basinProviderMock) Create(
-	_ context.Context, ns string, _ string, _ basincapnp.Schema, owner common.Address,
-) error {
-	bp.owner[ns] = owner.Hex()
+func (bp *basinProviderMock) Reconnect() error {
 	return nil
 }

--- a/pkg/basinprovider/provider_test.go
+++ b/pkg/basinprovider/provider_test.go
@@ -58,5 +58,13 @@ func newServer() *BasinProvider {
 		_ = rpc.Serve(lis, bootstrapClient)
 	}()
 
-	return New(srv)
+	return &BasinProvider{
+		p:        srv,
+		provider: "mock",
+		ctx:      context.Background(),
+		cancel: func() {
+			close(make(chan struct{}))
+		},
+	}
+
 }


### PR DESCRIPTION
When the remote restarts, active publications will abort when they try to push new data. This implements a simple retry. We should probably do something more advanced here with exponential backoff + limit the attempts, but adding this for now.