### PR TITLE
feat: add `--format` flag to `deals` for `table` or `json`

### DIFF
--- a/internal/app/basin_provider.go
+++ b/internal/app/basin_provider.go
@@ -10,10 +10,10 @@ import (
 
 // DealInfo represents information about a deal.
 type DealInfo struct {
-	CID        string
-	Timestamp  int64
-	Size       uint32
-	IsArchived bool
+	CID        string `json:"cid"`
+	Timestamp  int64  `json:"timestamp"`
+	Size       uint32 `json:"size"`
+	IsArchived bool   `json:"is_archived"`
 }
 
 // BasinProvider ...


### PR DESCRIPTION
## Summary

This adds a small feature to format the output of `deals` as either a table (default) or json. It also makes small changes to the README for a SUPERUSER publication creation requirement and a simple example of how to use Basin with Supabase.

## Details

Here's an example of how it works:
```sh
> basin publication deals --publication wxm2.date_2023_10_18 --latest 10 --format json
[{"cid":"Links/87/Hash/Links/63/Hash/Links/0/Hash","created":"bafybeigai657fdzj3ihe3sb4rb4ahwyeo5z57fsi3qgkuh52hgwztkq3eu","size":59303838,"is_archived":false},{"cid":"Links/87/Hash/Links/63/Hash/Links/0/Hash","created":"bafybeigai657fdzj3ihe3sb4rb4ahwyeo5z57fsi3qgkuh52hgwztkq3eu","size":59298226,"is_archived":false}]
```
- Note: it appears the current output doesn't map things properly. I didn't want to touch this since I'm assuming the mis-mapping is due to future changes we're making, but for example, you can see the CID is in the wrong column:
  ```md
    +------------------------------------------+----------+-------------------------------------------------------------+----------+
    |                   CID                    |   SIZE   |                           CREATED                           | ARCHIVED |
    +------------------------------------------+----------+-------------------------------------------------------------+----------+
    | Links/87/Hash/Links/63/Hash/Links/0/Hash | 59303838 | bafybeigai657fdzj3ihe3sb4rb4ahwyeo5z57fsi3qgkuh52hgwztkq3eu | N        |
    | Links/87/Hash/Links/63/Hash/Links/0/Hash | 59298226 | bafybeigai657fdzj3ihe3sb4rb4ahwyeo5z57fsi3qgkuh52hgwztkq3eu | N        |
    +------------------------------------------+----------+-------------------------------------------------------------+----------+
  ```

- Added JSON type annotations to the `DealInfo` struct under `internal/app/basin_provider.go`:
  ```go
   type DealInfo struct {
	CID        string `json:"cid"`
	Created    string `json:"created"`
	Size       uint32 `json:"size"`
	IsArchived bool   `json:"is_archived"`
   }
   ```
- In `cmd/basin/publication.go`, added a `format` option:
  ```go
  &cli.StringFlag{
    Name:        "format",
    Usage:       "The output format (table or json)",
    Destination: &format,
    Value:       "table",
  }
  ```
  This will let a `--format` flag be passed with either `table` or `json`, and it errors if an invalid string is passed:
  ```go
   if format == "table" {
      table := tablewriter.NewWriter(os.Stdout)
      table.SetHeader([]string{"CID", "Size", "Created", "Archived"})
      
      for _, deal := range deals {
	      isArchived := "N"
	      if deal.IsArchived {
		      isArchived = "Y"
	      }
	      table.Append([]string{deal.CID, fmt.Sprintf("%d", deal.Size), deal.Created, isArchived})
      }
      table.Render()
    } else if format == "json" {
      jsonData, err := json.Marshal(deals)
      if err != nil {
	      return fmt.Errorf("error serializing deals to JSON")
      }
      fmt.Println(string(jsonData))
    } else {
      return fmt.Errorf("invalid format: %s", format)
    }
  ```
- Tested by manually building since it doesn't seem like there's an existing test for this and I didn't want to mess with anything.