### PR TITLE
fix: `retrieve` to stdout failure

### DIFF
--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -642,7 +642,7 @@ func newRetrieveCommand() *cli.Command {
 
 			if output == "-" {
 				// Create a temporary file only for writing to stdout case
-				tmpFile, err := os.CreateTemp("", fmt.Sprintf("%s.car", arg))
+				tmpFile, err = os.CreateTemp("", fmt.Sprintf("%s.car", arg))
 				if err != nil {
 					return fmt.Errorf("failed to create temporary file: %s", err)
 				}


### PR DESCRIPTION
## Summary

Fixes a bug where `vaults retrieve -o - ...` fails.

## Details

The `retrieve` command with `-o -` should write to stdout. However, this was not working due to a small operator typo in which the `tmpFile` variable was not being assigned a value, so the write to stdout wasn't executing because `tmpFile` was seen as `nil`. This was due to the usage of `:=` over `=` within a conditional block scope.

## How it was tested

Build & then run `vaults retrieve --output - bafybeigpvzdvjgde5a6ayj7265a6ns3i4mvhhr6pqtlebpil5imkeh4ncy | car extract` to pipe the output to car extract, which unpacks the car file from stdout successfully.