### PR TITLE
handles err on writing an event

### DIFF
--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -565,7 +565,7 @@ func newListEventsCommand() *cli.Command {
 
 			if format == "table" {
 				table := tablewriter.NewWriter(os.Stdout)
-				table.SetHeader([]string{"CID", "Size", "Timestamp", "Archived", "Cache Expiry"})
+				table.SetHeader([]string{"CID", "Timestamp", "Archived", "Cache Expiry"})
 
 				for _, event := range events {
 					isArchived := "N"
@@ -577,7 +577,7 @@ func newListEventsCommand() *cli.Command {
 						timestamp = time.Unix(event.Timestamp, 0).Format(time.RFC3339)
 					}
 					table.Append([]string{
-						event.CID, fmt.Sprintf("%d", event.Size), timestamp, isArchived, event.CacheExpiry,
+						event.CID, timestamp, isArchived, event.CacheExpiry,
 					})
 				}
 				table.Render()

--- a/internal/app/models.go
+++ b/internal/app/models.go
@@ -35,7 +35,6 @@ type CacheDuration uint32
 type EventInfo struct {
 	CID         string `json:"cid"`
 	Timestamp   int64  `json:"timestamp"`
-	Size        uint32 `json:"size"`
 	IsArchived  bool   `json:"is_archived"`
 	CacheExpiry string `json:"cache_expiry"`
 }

--- a/pkg/vaultsprovider/provider.go
+++ b/pkg/vaultsprovider/provider.go
@@ -149,5 +149,17 @@ func (bp *VaultsProvider) WriteVaultEvent(ctx context.Context, params app.WriteV
 		_ = resp.Body.Close()
 	}()
 
+	if resp.StatusCode != http.StatusOK {
+		type response struct {
+			Error string
+		}
+		var r response
+		if err := json.NewDecoder(resp.Body).Decode(&r); err != nil {
+			return fmt.Errorf("failed to decode response: %s", err)
+		}
+
+		return fmt.Errorf(r.Error)
+	}
+
 	return nil
 }


### PR DESCRIPTION
When writing an event, the CLI was capturing errors in the HTTP call. That gave the false feeling that the event was uploaded with success, but it was not. 

This PR also removes the SIZE column, when listing events.