### PR TITLE
feat: signing pkg for programmatic access

### DIFF
--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -162,7 +162,7 @@ func newStreamCommand() *cli.Command {
 		ArgsUsage: "<vault_name>",
 		Description: "The daemon will continuously stream database changes (except deletions) \n" +
 			"to the vault, as long as the daemon is actively running.\n\n" +
-			"EXAMPLE:\n\nvaults stream --vault my.vault --private-key 0x1234abcd",
+			"EXAMPLE:\n\nvaults stream --private-key 0x1234abcd my.vault",
 
 		Flags: []cli.Flag{
 			&cli.StringFlag{

--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -3,6 +3,7 @@ package main
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -625,7 +626,7 @@ func newSignCommand() *cli.Command {
 			if err != nil {
 				return fmt.Errorf("failed to sign file: %s", err)
 			}
-			signature := signing.SignatureBytesToHex(signatureBytes)
+			signature := hex.EncodeToString(signatureBytes)
 			fmt.Println(signature)
 
 			return nil

--- a/cmd/vaults/main.go
+++ b/cmd/vaults/main.go
@@ -36,6 +36,7 @@ func main() {
 			newWriteCommand(),
 			newListCommand(),
 			newListEventsCommand(),
+			newSignCommand(),
 			newRetrieveCommand(),
 			newWalletCommand(),
 		},

--- a/internal/app/uploader.go
+++ b/internal/app/uploader.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"crypto/ecdsa"
+	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -45,10 +46,10 @@ func (bu *VaultsUploader) Upload(
 
 	signer := signing.NewSigner(bu.privateKey)
 	signatureBytes, err := signer.SignFile(filepath)
-	signature := signing.SignatureBytesToHex(signatureBytes)
 	if err != nil {
 		return fmt.Errorf("signing the file: %s", err)
 	}
+	signature := hex.EncodeToString(signatureBytes)
 
 	filename := filepath
 	if strings.Contains(filepath, "/") {

--- a/internal/app/uploader.go
+++ b/internal/app/uploader.go
@@ -1,19 +1,14 @@
 package app
 
 import (
-	"bufio"
 	"context"
 	"crypto/ecdsa"
-	"encoding/hex"
 	"fmt"
 	"io"
-	"log"
 	"os"
 	"strings"
 
-	"github.com/ethereum/go-ethereum/common"
-	"github.com/ethereum/go-ethereum/crypto"
-	"golang.org/x/crypto/sha3"
+	"github.com/tablelandnetwork/basin-cli/pkg/signing"
 )
 
 // VaultsUploader contains logic of uploading Parquet files to Vaults Provider.
@@ -48,8 +43,9 @@ func (bu *VaultsUploader) Upload(
 		_ = f.Close()
 	}()
 
-	signer := NewSigner(bu.privateKey)
-	signature, err := signer.SignFile(filepath)
+	signer := signing.NewSigner(bu.privateKey)
+	signatureBytes, err := signer.SignFile(filepath)
+	signature := signing.SignatureBytesToHex(signatureBytes)
 	if err != nil {
 		return fmt.Errorf("signing the file: %s", err)
 	}
@@ -66,7 +62,7 @@ func (bu *VaultsUploader) Upload(
 		Content:     f,
 		Filename:    filename,
 		ProgressBar: progress,
-		Signature:   hex.EncodeToString(signature),
+		Signature:   signature,
 		Size:        sz,
 	}
 
@@ -75,79 +71,4 @@ func (bu *VaultsUploader) Upload(
 	}
 
 	return nil
-}
-
-// Signer allows you to sign a big stream of bytes by calling Sum multiple times, then Sign.
-type Signer struct {
-	state      crypto.KeccakState
-	privateKey *ecdsa.PrivateKey
-}
-
-// NewSigner creates a new signer.
-func NewSigner(pk *ecdsa.PrivateKey) *Signer {
-	return &Signer{
-		state:      sha3.NewLegacyKeccak256().(crypto.KeccakState),
-		privateKey: pk,
-	}
-}
-
-// Sum updates the hash state with a new chunk.
-func (s *Signer) Sum(chunk []byte) {
-	s.state.Write(chunk)
-}
-
-// Sign signs the internal state.
-func (s *Signer) Sign() ([]byte, error) {
-	var h common.Hash
-	_, _ = s.state.Read(h[:])
-	signature, err := crypto.Sign(h.Bytes(), s.privateKey)
-	if err != nil {
-		return []byte{}, fmt.Errorf("sign: %s", err)
-	}
-
-	return signature, nil
-}
-
-// SignFile signs an entire file.
-func (s *Signer) SignFile(filename string) ([]byte, error) {
-	f, err := os.Open(filename)
-	if err != nil {
-		return []byte{}, fmt.Errorf("error to read [file=%v]: %v", filename, err.Error())
-	}
-
-	defer func() {
-		_ = f.Close()
-	}()
-
-	nBytes, nChunks := int64(0), int64(0)
-	r := bufio.NewReader(f)
-	buf := make([]byte, 0, 4*1024)
-	for {
-		n, err := r.Read(buf[:cap(buf)])
-		buf = buf[:n]
-		if n == 0 {
-			if err == nil {
-				continue
-			}
-			if err == io.EOF {
-				break
-			}
-			log.Fatal(err)
-		}
-		nChunks++
-		nBytes += int64(len(buf))
-
-		s.Sum(buf)
-
-		if err != nil && err != io.EOF {
-			log.Fatal(err)
-		}
-	}
-
-	signature, err := s.Sign()
-	if err != nil {
-		log.Fatal("failed to sign")
-	}
-
-	return signature, nil
 }

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -1,0 +1,96 @@
+package signing
+
+import (
+	"bufio"
+	"crypto/ecdsa"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"os"
+
+	"github.com/ethereum/go-ethereum/common"
+	"github.com/ethereum/go-ethereum/crypto"
+	"golang.org/x/crypto/sha3"
+)
+
+// Signer allows you to sign a big stream of bytes by calling Sum multiple times, then Sign.
+type Signer struct {
+	state      crypto.KeccakState
+	privateKey *ecdsa.PrivateKey
+}
+
+// LoadPrivateKey creates an ecdsa.PrivateKey from a hex-encoded string.
+func LoadPrivateKey(hexKey string) (*ecdsa.PrivateKey, error) {
+	return crypto.HexToECDSA(hexKey)
+}
+
+// NewSigner creates a new signer with a private key and internal state.
+func NewSigner(pk *ecdsa.PrivateKey) *Signer {
+	return &Signer{
+		state:      sha3.NewLegacyKeccak256().(crypto.KeccakState),
+		privateKey: pk,
+	}
+}
+
+// Sum updates the hash state with a new chunk.
+func (s *Signer) Sum(chunk []byte) {
+	s.state.Write(chunk)
+}
+
+// Sign returns the signature of the hash state.
+func (s *Signer) signState() ([]byte, error) {
+	var h common.Hash
+	_, _ = s.state.Read(h[:])
+	signature, err := crypto.Sign(h.Bytes(), s.privateKey)
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to sign state: %s", err)
+	}
+
+	return signature, nil
+}
+
+// SignFile returns the signature of a signed file.
+func (s *Signer) SignFile(filePath string) (string, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return "", fmt.Errorf("failed to open file: %s", err.Error())
+	}
+	defer file.Close()
+
+	// Check if the file is empty and return an error if it is
+	info, err := file.Stat()
+	if err != nil {
+		return "", fmt.Errorf("failed to get file info: %s", err.Error())
+	}
+	if info.Size() == 0 {
+		return "", fmt.Errorf("failed to create signature: %s", "file is empty")
+	}
+
+	nBytes, nChunks := int64(0), int64(0)
+	r := bufio.NewReader(file)
+	buf := make([]byte, 0, 4*1024) // 4KB buffer
+	for {
+		n, err := r.Read(buf[:cap(buf)])
+		buf = buf[:n]
+		if n == 0 {
+			if err == nil {
+				continue
+			}
+			if err == io.EOF {
+				break
+			}
+			return "", fmt.Errorf("read error: %s", err)
+		}
+		nChunks++
+		nBytes += int64(len(buf))
+
+		s.Sum(buf)
+	}
+
+	signature, err := s.signState()
+	if err != nil {
+		return "", fmt.Errorf("failed to sign: %s", err)
+	}
+
+	return hex.EncodeToString(signature), nil
+}

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -65,7 +65,7 @@ func (s *Signer) SignFile(filename string) ([]byte, error) {
 		return []byte{}, fmt.Errorf("failed to get file info: %s", err.Error())
 	}
 	if info.Size() == 0 {
-		return []byte{}, fmt.Errorf("error with file: %s", "content is empty")
+		return []byte{}, fmt.Errorf("error with file: content is empty")
 	}
 
 	nBytes, nChunks := int64(0), int64(0)
@@ -96,6 +96,22 @@ func (s *Signer) SignFile(filename string) ([]byte, error) {
 	signature, err := s.Sign()
 	if err != nil {
 		return []byte{}, fmt.Errorf("failed to sign [file=%v]: %s", filename, err.Error())
+	}
+
+	return signature, nil
+}
+
+// SignBytes signs the provided bytes, returning the signature as a byte slice.
+func (s *Signer) SignBytes(data []byte) ([]byte, error) {
+	if len(data) == 0 {
+		return []byte{}, fmt.Errorf("error with data: content is empty")
+	}
+
+	s.Sum(data)
+
+	signature, err := s.Sign()
+	if err != nil {
+		return []byte{}, fmt.Errorf("failed to sign data: %s", err.Error())
 	}
 
 	return signature, nil

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -124,7 +124,7 @@ func (s *Signer) SignBytes(data []byte) ([]byte, error) {
 	return signature, nil
 }
 
-// signatureBytesToHex converts a byte slice to a hex-encoded string.
+// SignatureBytesToHex converts a byte slice to a hex-encoded string.
 func SignatureBytesToHex(b []byte) string {
 	return hex.EncodeToString(b)
 }

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -19,9 +19,16 @@ type Signer struct {
 	privateKey *ecdsa.PrivateKey
 }
 
-// HexToECDSA parses a hex encoded private key to an ECDSA private key.
+// HexToECDSA parses a hex-encoded secp256k1 private key string to an ECDSA
+// private key.
 func HexToECDSA(hexKey string) (*ecdsa.PrivateKey, error) {
 	return crypto.HexToECDSA(hexKey)
+}
+
+// FileToECDSA parses a file path to a hex-encoded secp256k1 private key to an
+// ECDSA private key.
+func FileToECDSA(hexPath string) (*ecdsa.PrivateKey, error) {
+	return crypto.LoadECDSA(hexPath)
 }
 
 // NewSigner creates a new signer.

--- a/pkg/signing/signing.go
+++ b/pkg/signing/signing.go
@@ -3,7 +3,6 @@ package signing
 import (
 	"bufio"
 	"crypto/ecdsa"
-	"encoding/hex"
 	"fmt"
 	"io"
 	"os"
@@ -122,9 +121,4 @@ func (s *Signer) SignBytes(data []byte) ([]byte, error) {
 	}
 
 	return signature, nil
-}
-
-// SignatureBytesToHex converts a byte slice to a hex-encoded string.
-func SignatureBytesToHex(b []byte) string {
-	return hex.EncodeToString(b)
 }

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestSigner(t *testing.T) {
-	privateKey, _ := LoadPrivateKey("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
+	privateKey, _ := HexToECDSA("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
 	signer := NewSigner(privateKey)
 
 	testCases := []struct {
@@ -38,7 +38,7 @@ func TestSigner(t *testing.T) {
 				tmpFile.Close()
 				return name, func() { os.Remove(name) }
 			},
-			wantErr: "failed to create signature: file is empty",
+			wantErr: "error with file: content is empty",
 		},
 		{
 			name: "should fail with non-existent file",
@@ -49,7 +49,7 @@ func TestSigner(t *testing.T) {
 				os.Remove(name)
 				return name, func() {}
 			},
-			wantErr: "failed to open file: open ",
+			wantErr: "error reading [file=",
 		},
 	}
 
@@ -107,13 +107,13 @@ func TestPrivateKey(t *testing.T) {
 		t.Run(tc.name, func(t *testing.T) {
 			pk := tc.setup()
 
-			hex, err := LoadPrivateKey(pk)
+			hex, err := HexToECDSA(pk)
 			if tc.wantErr != "" {
 				require.Error(t, err, "Expected an error for %v", tc.name)
-				require.EqualErrorf(t, err, tc.wantErr, "LoadPrivateKey() error = %v, wantErr %v", err, tc.wantErr)
+				require.EqualErrorf(t, err, tc.wantErr, "HexToECDSA() error = %v, wantErr %v", err, tc.wantErr)
 			} else {
-				require.NoError(t, err, "LoadPrivateKey() unexpected error = %v", err)
-				require.NotNil(t, hex, "LoadPrivateKey() returned nil")
+				require.NoError(t, err, "HexToECDSA() unexpected error = %v", err)
+				require.NotNil(t, hex, "HexToECDSA() returned nil")
 			}
 		})
 	}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -24,20 +24,30 @@ func TestSignFile(t *testing.T) {
 				tmpFile, _ := os.CreateTemp("", "test_file")
 				name := tmpFile.Name()
 				content := []byte("data to be signed")
-				tmpFile.Write(content)
-				tmpFile.Close()
-				return name, func() { os.Remove(name) }
+				_, err := tmpFile.Write(content)
+				require.NoError(t, err, "Error writing to file")
+				err = tmpFile.Close()
+				require.NoError(t, err, "Error closing file")
+				return name, func() {
+					err = os.Remove(name)
+					require.NoError(t, err, "Error removing file")
+				}
 			},
-			wantErr:           "",
-			expectedSignature: "6ddb61a19b9df71136b48c80b2e86e7e20313d5eec0de9210802335b300ba8df6c332d35a5d753a028d703769fd9b66d7ce5902d80369750cf55118b1679d84900",
+			wantErr: "",
+			expectedSignature: "6ddb61a19b9df71136b48c80b2e86e7e20313d5eec0de9210802335b3" +
+				"00ba8df6c332d35a5d753a028d703769fd9b66d7ce5902d80369750cf55118b1679d84900",
 		},
 		{
 			name: "should fail with empty file",
 			setup: func() (filename string, cleanup func()) {
 				tmpFile, _ := os.CreateTemp("", "test_file")
 				name := tmpFile.Name()
-				tmpFile.Close()
-				return name, func() { os.Remove(name) }
+				err := tmpFile.Close()
+				require.NoError(t, err, "Error closing file")
+				return name, func() {
+					err = os.Remove(name)
+					require.NoError(t, err, "Error removing file")
+				}
 			},
 			wantErr: "error with file: content is empty",
 		},
@@ -46,8 +56,10 @@ func TestSignFile(t *testing.T) {
 			setup: func() (filename string, cleanup func()) {
 				tmpFile, _ := os.CreateTemp("", "test_file")
 				name := tmpFile.Name()
-				tmpFile.Close()
-				os.Remove(name)
+				err := tmpFile.Close()
+				require.NoError(t, err, "Error closing file")
+				err = os.Remove(name)
+				require.NoError(t, err, "Error removing file")
 				return name, func() {}
 			},
 			wantErr: "error reading [file=",
@@ -83,10 +95,11 @@ func TestSignBytes(t *testing.T) {
 		expectedSignature string
 	}{
 		{
-			name:              "should sign bytes",
-			content:           []byte("data to be signed"),
-			wantErr:           "",
-			expectedSignature: "6ddb61a19b9df71136b48c80b2e86e7e20313d5eec0de9210802335b300ba8df6c332d35a5d753a028d703769fd9b66d7ce5902d80369750cf55118b1679d84900",
+			name:    "should sign bytes",
+			content: []byte("data to be signed"),
+			wantErr: "",
+			expectedSignature: "6ddb61a19b9df71136b48c80b2e86e7e20313d5eec0de9210802335b3" +
+				"00ba8df6c332d35a5d753a028d703769fd9b66d7ce5902d80369750cf55118b1679d84900",
 		},
 		{
 			name:    "should fail with empty bytes",
@@ -97,7 +110,6 @@ func TestSignBytes(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-
 			signatureBytes, err := signer.SignBytes(tc.content)
 			signature := SignatureBytesToHex(signatureBytes)
 			if tc.wantErr != "" {
@@ -131,9 +143,14 @@ func TestPrivateKey(t *testing.T) {
 				tmpFile, _ := os.CreateTemp("", "test_file")
 				name := tmpFile.Name()
 				content := []byte("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
-				tmpFile.Write(content)
-				tmpFile.Close()
-				return pk, name, func() { os.Remove(name) }
+				_, err := tmpFile.Write(content)
+				require.NoError(t, err, "Error writing to file")
+				err = tmpFile.Close()
+				require.NoError(t, err, "Error closing file")
+				return pk, name, func() {
+					err = os.Remove(name)
+					require.NoError(t, err, "Error removing file")
+				}
 			},
 			wantErr: "",
 		},
@@ -158,8 +175,12 @@ func TestPrivateKey(t *testing.T) {
 			setup: func() (pk string, filename string, cleanup func()) {
 				tmpFile, _ := os.CreateTemp("", "test_file")
 				name := tmpFile.Name()
-				tmpFile.Close()
-				return pk, name, func() { os.Remove(name) }
+				err := tmpFile.Close()
+				require.NoError(t, err, "Error closing file")
+				return pk, name, func() {
+					err = os.Remove(name)
+					require.NoError(t, err, "Error removing file")
+				}
 			},
 			wantErr: "key file too short, want 64 hex characters",
 		},

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -2,6 +2,7 @@ package signing
 
 import (
 	"crypto/ecdsa"
+	"encoding/hex"
 	"os"
 	"testing"
 
@@ -72,7 +73,7 @@ func TestSignFile(t *testing.T) {
 			defer cleanup()
 
 			signatureBytes, err := signer.SignFile(filename)
-			signature := SignatureBytesToHex(signatureBytes)
+			signature := hex.EncodeToString(signatureBytes)
 			if tc.wantErr != "" {
 				require.Error(t, err, "Expected an error for %v", tc.name)
 				require.Contains(t, err.Error(), tc.wantErr, "SignFile() error = %v, wantErr %v", err, tc.wantErr)
@@ -111,7 +112,7 @@ func TestSignBytes(t *testing.T) {
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
 			signatureBytes, err := signer.SignBytes(tc.content)
-			signature := SignatureBytesToHex(signatureBytes)
+			signature := hex.EncodeToString(signatureBytes)
 			if tc.wantErr != "" {
 				require.Error(t, err, "Expected an error for %v", tc.name)
 				require.Contains(t, err.Error(), tc.wantErr, "SignBytes() error = %v, wantErr %v", err, tc.wantErr)
@@ -153,36 +154,6 @@ func TestPrivateKey(t *testing.T) {
 				}
 			},
 			wantErr: "",
-		},
-		{
-			name: "should fail to load 0x prefixed string",
-			setup: func() (pk string, filename string, cleanup func()) {
-				pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
-				return pk, "", func() {}
-			},
-			wantErr: "invalid hex character 'x' in private key",
-		},
-		{
-			name: "should fail to load random string",
-			setup: func() (pk string, filename string, cleanup func()) {
-				pk = "1234abcd"
-				return pk, "", func() {}
-			},
-			wantErr: "invalid length, need 256 bits",
-		},
-		{
-			name: "should fail to load empty private key file",
-			setup: func() (pk string, filename string, cleanup func()) {
-				tmpFile, _ := os.CreateTemp("", "test_file")
-				name := tmpFile.Name()
-				err := tmpFile.Close()
-				require.NoError(t, err, "Error closing file")
-				return pk, name, func() {
-					err = os.Remove(name)
-					require.NoError(t, err, "Error removing file")
-				}
-			},
-			wantErr: "key file too short, want 64 hex characters",
 		},
 	}
 

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -1,0 +1,119 @@
+package signing
+
+import (
+	"os"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestSigner(t *testing.T) {
+	privateKey, _ := LoadPrivateKey("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
+	signer := NewSigner(privateKey)
+
+	testCases := []struct {
+		name              string
+		setup             func() (filename string, cleanup func())
+		wantErr           string
+		expectedSignature string
+	}{
+		{
+			name: "should sign with content",
+			setup: func() (filename string, cleanup func()) {
+				tmpFile, _ := os.CreateTemp("", "test_file")
+				name := tmpFile.Name()
+				content := []byte("data to be signed")
+				tmpFile.Write(content)
+				tmpFile.Close()
+				return name, func() { os.Remove(name) }
+			},
+			wantErr:           "",
+			expectedSignature: "6ddb61a19b9df71136b48c80b2e86e7e20313d5eec0de9210802335b300ba8df6c332d35a5d753a028d703769fd9b66d7ce5902d80369750cf55118b1679d84900",
+		},
+		{
+			name: "should fail with empty file",
+			setup: func() (filename string, cleanup func()) {
+				tmpFile, _ := os.CreateTemp("", "test_file")
+				name := tmpFile.Name()
+				tmpFile.Close()
+				return name, func() { os.Remove(name) }
+			},
+			wantErr: "failed to create signature: file is empty",
+		},
+		{
+			name: "should fail with non-existent file",
+			setup: func() (filename string, cleanup func()) {
+				tmpFile, _ := os.CreateTemp("", "test_file")
+				name := tmpFile.Name()
+				tmpFile.Close()
+				os.Remove(name)
+				return name, func() {}
+			},
+			wantErr: "failed to open file: open ",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			filename, cleanup := tc.setup()
+			defer cleanup()
+
+			signature, err := signer.SignFile(filename)
+			if tc.wantErr != "" {
+				require.Error(t, err, "Expected an error for %v", tc.name)
+				require.Contains(t, err.Error(), tc.wantErr, "SignFile() error = %v, wantErr %v", err, tc.wantErr)
+			} else {
+				require.NoError(t, err, "SignFile() unexpected error = %v", err)
+				require.Equal(t, tc.expectedSignature, signature, "Signature mismatch")
+			}
+		})
+	}
+}
+
+func TestPrivateKey(t *testing.T) {
+	testCases := []struct {
+		name    string
+		setup   func() (pk string)
+		wantErr string
+	}{
+		{
+			name: "should load a real private key",
+			setup: func() (pk string) {
+				pk = "59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+				return pk
+			},
+			wantErr: "",
+		},
+		{
+			name: "should fail to load 0x prefixed key",
+			setup: func() (pk string) {
+				pk = "0x59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d"
+				return pk
+			},
+			wantErr: "invalid hex character 'x' in private key",
+		},
+		{
+			name: "should fail to load random string",
+			setup: func() (pk string) {
+				pk = "1234abcd"
+				return pk
+			},
+			wantErr: "invalid length, need 256 bits",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			pk := tc.setup()
+
+			hex, err := LoadPrivateKey(pk)
+			if tc.wantErr != "" {
+				require.Error(t, err, "Expected an error for %v", tc.name)
+				require.EqualErrorf(t, err, tc.wantErr, "LoadPrivateKey() error = %v, wantErr %v", err, tc.wantErr)
+			} else {
+				require.NoError(t, err, "LoadPrivateKey() unexpected error = %v", err)
+				require.NotNil(t, hex, "LoadPrivateKey() returned nil")
+			}
+		})
+	}
+}

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -58,7 +58,8 @@ func TestSigner(t *testing.T) {
 			filename, cleanup := tc.setup()
 			defer cleanup()
 
-			signature, err := signer.SignFile(filename)
+			signatureBytes, err := signer.SignFile(filename)
+			signature := SignatureBytesToHex(signatureBytes)
 			if tc.wantErr != "" {
 				require.Error(t, err, "Expected an error for %v", tc.name)
 				require.Contains(t, err.Error(), tc.wantErr, "SignFile() error = %v, wantErr %v", err, tc.wantErr)

--- a/pkg/signing/signing_test.go
+++ b/pkg/signing/signing_test.go
@@ -7,7 +7,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSigner(t *testing.T) {
+func TestSignFile(t *testing.T) {
 	privateKey, _ := HexToECDSA("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
 	signer := NewSigner(privateKey)
 
@@ -18,7 +18,7 @@ func TestSigner(t *testing.T) {
 		expectedSignature string
 	}{
 		{
-			name: "should sign with content",
+			name: "should sign file with content",
 			setup: func() (filename string, cleanup func()) {
 				tmpFile, _ := os.CreateTemp("", "test_file")
 				name := tmpFile.Name()
@@ -65,6 +65,45 @@ func TestSigner(t *testing.T) {
 				require.Contains(t, err.Error(), tc.wantErr, "SignFile() error = %v, wantErr %v", err, tc.wantErr)
 			} else {
 				require.NoError(t, err, "SignFile() unexpected error = %v", err)
+				require.Equal(t, tc.expectedSignature, signature, "Signature mismatch")
+			}
+		})
+	}
+}
+
+func TestSignByes(t *testing.T) {
+	privateKey, _ := HexToECDSA("59c6995e998f97a5a0044966f0945389dc9e86dae88c7a8412f4603b6b78690d")
+	signer := NewSigner(privateKey)
+
+	testCases := []struct {
+		name              string
+		content           []byte
+		wantErr           string
+		expectedSignature string
+	}{
+		{
+			name:              "should sign bytes",
+			content:           []byte("data to be signed"),
+			wantErr:           "",
+			expectedSignature: "6ddb61a19b9df71136b48c80b2e86e7e20313d5eec0de9210802335b300ba8df6c332d35a5d753a028d703769fd9b66d7ce5902d80369750cf55118b1679d84900",
+		},
+		{
+			name:    "should fail with empty bytes",
+			content: []byte(""),
+			wantErr: "error with data: content is empty",
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+
+			signatureBytes, err := signer.SignBytes(tc.content)
+			signature := SignatureBytesToHex(signatureBytes)
+			if tc.wantErr != "" {
+				require.Error(t, err, "Expected an error for %v", tc.name)
+				require.Contains(t, err.Error(), tc.wantErr, "SignBytes() error = %v, wantErr %v", err, tc.wantErr)
+			} else {
+				require.NoError(t, err, "SignBytes() unexpected error = %v", err)
 				require.Equal(t, tc.expectedSignature, signature, "Signature mismatch")
 			}
 		})


### PR DESCRIPTION
## Summary

Adds a pkg for signing requests and a `sign` command, modeled off of [the signer CLI](https://github.com/tablelandnetwork/basin-cli/blob/bcalza/signer/cmd/signer/main.go) and [uploader.go](https://github.com/tablelandnetwork/basin-cli/blob/main/internal/app/uploader.go). Closes [ENG-787](https://linear.app/tableland/issue/ENG-787/allow-vaults-account-address-to-take-a-string).

## Details

It offers a few methods:

- `HexToECDSA`: Loads a private key from the given string and creates an ECDSA private key.
- `FileToECDSA`: Loads a private key from a file and creates an ECDSA private key.
- `NewSigner`: Creates a new signer with the given private key, provided by `LoadPrivateKey`.
- `SignFile`: Signs the given file with the signer and returns the signature as bytes.
- `SignBytes`: Signs the given bytes with the signer and returns the signature as bytes.
- `SignatureBytesToHex`: Converts bytes so they can be used in the URL POST request to write data to a vault.

## How it was tested

You can find the tests to ensure correct usage. Namely, I tested the CLI `signers` signature matched with the example I set up in the tests. I also created a working demo example here: https://github.com/dtbuchholz/demo-textile-http-api