### PR TITLE
Cache and cold storage retrieve the same content

### DIFF
--- a/README.md
+++ b/README.md
@@ -184,17 +184,12 @@ You can retrieve a file from a vault by running:
 vaults retrieve bafybeifr5njnrw67yyb2h2t7k6ukm3pml4fgphsxeurqcmgmeb7omc2vlq
 ```
 
-You can also specify where to save the file:
+You can specify the file where the retrieved content will be save:
 
 ```bash
-vaults retrieve --output /path/to/dir bafybeifr5njnrw67yyb2h2t7k6ukm3pml4fgphsxeurqcmgmeb7omc2vlq
+vaults retrieve --output filename bafybeifr5njnrw67yyb2h2t7k6ukm3pml4fgphsxeurqcmgmeb7omc2vlq
 ```
 
-Or stream the file to stdout the `-` value (note: the short form `-o` is for `--output`), and then pipe it to something like [`car extract`](https://github.com/ipld/go-car) to unpack the CAR file's contents:
-
-```bash
-vaults retrieve -o - bafybeifr5njnrw67yyb2h2t7k6ukm3pml4fgphsxeurqcmgmeb7omc2vlq | car extract
-```
 
 ## Development
 

--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -597,15 +597,15 @@ func newRetrieveCommand() *cli.Command {
 		Usage:     "Retrieve an event by CID",
 		ArgsUsage: "<event_cid>",
 		Description: "Retrieving an event will download the event's CAR file into the \n" +
-			"current directory, a provided directory path, or to stdout.\n\n" +
-			"EXAMPLE:\n\nvaults retrieve --output /path/to/dir bafy...",
+			"specified file or to stdout.\n\n" +
+			"EXAMPLE:\n\nvaults retrieve --output filename bafy...",
 		Flags: []cli.Flag{
 			&cli.StringFlag{
 				Name:        "output",
 				Aliases:     []string{"o"},
 				Category:    "OPTIONAL:",
-				Usage:       "Output directory path, or '-' for stdout",
-				DefaultText: "current directory",
+				Usage:       "The file to store the retrieved content, or '-' for stdout",
+				DefaultText: "stdout",
 				Destination: &output,
 			},
 			&cli.StringFlag{

--- a/internal/app/retriever_test.go
+++ b/internal/app/retriever_test.go
@@ -2,10 +2,8 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"io"
 	"os"
-	"path"
 	"testing"
 
 	"github.com/ipfs/go-cid"
@@ -14,15 +12,14 @@ import (
 
 func TestRetrieverFileOutput(t *testing.T) {
 	retriever := NewRetriever(&vaultsProviderMock{}, 0)
-	output := t.TempDir()
+	output, err := os.CreateTemp("", "")
+	require.NoError(t, err)
 	cid := cid.Cid{}
-	err := retriever.Retrieve(context.Background(), cid, output)
+	err = retriever.Retrieve(context.Background(), cid, output.Name())
 	require.NoError(t, err)
 
-	f, err := os.Open(path.Join(output, fmt.Sprintf("%s-%s", cid.String(), "sample.txt")))
-	require.NoError(t, err)
-
-	data, err := io.ReadAll(f)
+	_, _ = output.Seek(0, 0)
+	data, err := io.ReadAll(output)
 	require.NoError(t, err)
 
 	require.Equal(t, []byte("Hello"), data)


### PR DESCRIPTION
This PR introduces the following changes:
- The `retrieve` command behavior is modified so that the `--output` flag is expected to be a filename
- When the CAR file is retrieved from cold storage, it is unpacked. That means both cache and cold storage should retrieve the same content