### PR TITLE
remove legacy config

### DIFF
--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -103,7 +103,7 @@ func newVaultCreateCommand() *cli.Command {
 				return fmt.Errorf("parse config: %s", err)
 			}
 
-			dir, _, err := defaultConfigLocationV2(cCtx.String("dir"))
+			dir, err := defaultConfigLocation(cCtx.String("dir"))
 			if err != nil {
 				return fmt.Errorf("default config location: %s", err)
 			}
@@ -116,7 +116,7 @@ func newVaultCreateCommand() *cli.Command {
 				_ = f.Close()
 			}()
 
-			cfg, err := loadConfigV2(path.Join(dir, "config.yaml"))
+			cfg, err := loadConfig(path.Join(dir, "config.yaml"))
 			if err != nil {
 				return fmt.Errorf("load config: %s", err)
 			}
@@ -187,12 +187,12 @@ func newStreamCommand() *cli.Command {
 				return err
 			}
 
-			dir, _, err := defaultConfigLocationV2(cCtx.String("dir"))
+			dir, err := defaultConfigLocation(cCtx.String("dir"))
 			if err != nil {
 				return fmt.Errorf("default config location: %s", err)
 			}
 
-			cfg, err := loadConfigV2(path.Join(dir, "config.yaml"))
+			cfg, err := loadConfig(path.Join(dir, "config.yaml"))
 			if err != nil {
 				return fmt.Errorf("load config: %s", err)
 			}
@@ -311,12 +311,12 @@ func newWriteCommand() *cli.Command {
 				return err
 			}
 
-			dir, _, err := defaultConfigLocationV2(cCtx.String("dir"))
+			dir, err := defaultConfigLocation(cCtx.String("dir"))
 			if err != nil {
 				return fmt.Errorf("default config location: %s", err)
 			}
 
-			cfg, err := loadConfigV2(path.Join(dir, "config.yaml"))
+			cfg, err := loadConfig(path.Join(dir, "config.yaml"))
 			if err != nil {
 				return fmt.Errorf("load config: %s", err)
 			}

--- a/cmd/vaults/config.go
+++ b/cmd/vaults/config.go
@@ -1,13 +1,12 @@
 package main
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path"
+	"strings"
 
 	"github.com/mitchellh/go-homedir"
-	"golang.org/x/exp/slog"
 	"gopkg.in/yaml.v3"
 )
 
@@ -19,21 +18,7 @@ const DefaultProviderHost = "https://basin.tableland.xyz"
 const DefaultWindowSize = 3600
 
 type config struct {
-	Publications map[string]publication `yaml:"publications"`
-}
-
-type configV2 struct {
 	Vaults map[string]vault `yaml:"vaults"`
-}
-
-type publication struct {
-	User         string `yaml:"user"`
-	Password     string `yaml:"password"`
-	Host         string `yaml:"host"`
-	Port         int    `yaml:"port"`
-	Database     string `yaml:"database"`
-	ProviderHost string `yaml:"provider_host"`
-	WindowSize   int64  `yaml:"window_size"`
 }
 
 type vault struct {
@@ -48,12 +33,6 @@ type vault struct {
 
 func newConfig() *config {
 	return &config{
-		Publications: make(map[string]publication),
-	}
-}
-
-func newConfigV2() *configV2 {
-	return &configV2{
 		Vaults: make(map[string]vault),
 	}
 }
@@ -72,20 +51,6 @@ func loadConfig(path string) (*config, error) {
 	return conf, nil
 }
 
-func loadConfigV2(path string) (*configV2, error) {
-	buf, err := os.ReadFile(path)
-	if err != nil {
-		return &configV2{}, err
-	}
-
-	conf := newConfigV2()
-	if err := yaml.Unmarshal(buf, conf); err != nil {
-		return &configV2{}, err
-	}
-
-	return conf, nil
-}
-
 func defaultConfigLocation(dir string) (string, error) {
 	if dir == "" {
 		// the default directory is home
@@ -95,96 +60,15 @@ func defaultConfigLocation(dir string) (string, error) {
 			return "", fmt.Errorf("home dir: %s", err)
 		}
 
-		dir = path.Join(dir, ".basin")
-	}
-
-	_, err := os.Stat(dir)
-	if os.IsNotExist(err) {
-		if err := os.Mkdir(dir, 0o755); err != nil {
-			return "", fmt.Errorf("mkdir: %s", err)
-		}
-	} else if err != nil {
-		return "", fmt.Errorf("is not exist: %s", err)
-	}
-
-	return dir, nil
-}
-
-func defaultConfigLocationV2(dir string) (string, bool, error) {
-	if dir == "" {
-		// the default directory is home
-		var err error
-		dir, err = homedir.Dir()
-		if err != nil {
-			return "", false, fmt.Errorf("home dir: %s", err)
-		}
-
 		dir = path.Join(dir, ".vaults")
 	}
 
-	_, err := os.Stat(dir)
-	doesNotExist := os.IsNotExist(err)
-	if doesNotExist {
-		if err := os.Mkdir(dir, 0o755); err != nil {
-			return "", doesNotExist, fmt.Errorf("mkdir: %s", err)
+	// ignore err if dir already exists
+	if err := os.Mkdir(dir, 0o755); err != nil {
+		if !strings.Contains(err.Error(), "file exists") {
+			return "", fmt.Errorf("mkdir: %s", err)
 		}
-	} else if err != nil {
-		return "", doesNotExist, fmt.Errorf("is not exist: %s", err)
 	}
 
-	return dir, !doesNotExist, nil
-}
-
-func migrateConfigV1ToV2() {
-	dirV1, err := defaultConfigLocation("")
-	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
-
-	dirV2, exists, err := defaultConfigLocationV2("")
-	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
-
-	// create v2 config.yaml if necessary
-	f, err := os.OpenFile(path.Join(dirV2, "config.yaml"), os.O_RDWR|os.O_CREATE, 0o666)
-	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
-	defer func() {
-		_ = f.Close()
-	}()
-
-	if exists {
-		return
-	}
-
-	// .basin/config.yaml does not exist, there's nothing to migrate
-	if _, err := os.Stat(path.Join(dirV1, "config.yaml")); errors.Is(err, os.ErrNotExist) {
-		return
-	}
-
-	cfgV1, err := loadConfig(path.Join(dirV1, "config.yaml"))
-	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
-
-	cfgV2, err := loadConfigV2(path.Join(dirV2, "config.yaml"))
-	if err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
-
-	for name, item := range cfgV1.Publications {
-		cfgV2.Vaults[name] = vault(item)
-	}
-
-	if err := yaml.NewEncoder(f).Encode(cfgV2); err != nil {
-		slog.Error(err.Error())
-		os.Exit(1)
-	}
+	return dir, nil
 }

--- a/cmd/vaults/main.go
+++ b/cmd/vaults/main.go
@@ -23,9 +23,6 @@ func init() {
 var version = "dev"
 
 func main() {
-	// migrate v1 config to v2 config
-	migrateConfigV1ToV2()
-
 	cliApp := &cli.App{
 		Name:    "vaults",
 		Usage:   "Continuously publish data from your database or file uploads to the Textile Vaults network.",


### PR DESCRIPTION
This PR removes the legacy config. See: [ENG-789](https://linear.app/tableland/issue/ENG-789/remove-basin-legacy-logic-for-readingcreating-config-file)

It should be straightforward to review because it's just a removal of code and renaming of V2. 

Note: if multiple processes are spawned some processes can still end up with misconfigured config value. This should be fixed by allowing the stream of multiple tables in a single process.