### PR TITLE
list cache duration together with vault's name

### DIFF
--- a/cmd/vaults/commands.go
+++ b/cmd/vaults/commands.go
@@ -378,10 +378,10 @@ func newListCommand() *cli.Command {
 			&cli.StringFlag{
 				Name:        "format",
 				Category:    "OPTIONAL:",
-				Usage:       "The output format (text or json)",
-				DefaultText: "text",
+				Usage:       "The output format (table or json)",
+				DefaultText: "table",
 				Destination: &format,
-				Value:       "text",
+				Value:       "table",
 			},
 		},
 		Action: func(cCtx *cli.Context) error {
@@ -396,10 +396,19 @@ func newListCommand() *cli.Command {
 				return fmt.Errorf("failed to list vaults: %s", err)
 			}
 
-			if format == "text" {
+			if format == "table" {
+				table := tablewriter.NewWriter(os.Stdout)
+				table.SetHeader([]string{"Vault", "Cache Duration"})
 				for _, vault := range vaults {
-					fmt.Printf("%s\n", vault)
+					cacheDuration := ""
+					if vault.CacheDuration != nil {
+						cacheDuration = fmt.Sprint(*vault.CacheDuration)
+					}
+					table.Append([]string{
+						string(vault.Vault), cacheDuration,
+					})
 				}
+				table.Render()
 			} else if format == "json" {
 				jsonData, err := json.Marshal(vaults)
 				if err != nil {

--- a/internal/app/models.go
+++ b/internal/app/models.go
@@ -9,6 +9,12 @@ import (
 // Vault represents a vault.
 type Vault string
 
+// VaultWithCacheDuration represents a vault with its cache.
+type VaultWithCacheDuration struct {
+	Vault         Vault          `json:"vault"`
+	CacheDuration *CacheDuration `json:"cache_duration"`
+}
+
 // Account represents an account.
 type Account struct {
 	address common.Address

--- a/internal/app/streamer_test.go
+++ b/internal/app/streamer_test.go
@@ -230,8 +230,8 @@ func (bp *vaultsProviderMock) CreateVault(
 	return nil
 }
 
-func (bp *vaultsProviderMock) ListVaults(_ context.Context, _ ListVaultsParams) ([]Vault, error) {
-	return []Vault{}, nil
+func (bp *vaultsProviderMock) ListVaults(_ context.Context, _ ListVaultsParams) ([]VaultWithCacheDuration, error) {
+	return []VaultWithCacheDuration{}, nil
 }
 
 func (bp *vaultsProviderMock) ListVaultEvents(

--- a/internal/app/vaults_provider.go
+++ b/internal/app/vaults_provider.go
@@ -11,7 +11,7 @@ import (
 // VaultsProvider defines Vaults API.
 type VaultsProvider interface {
 	CreateVault(context.Context, CreateVaultParams) error
-	ListVaults(context.Context, ListVaultsParams) ([]Vault, error)
+	ListVaults(context.Context, ListVaultsParams) ([]VaultWithCacheDuration, error)
 	ListVaultEvents(context.Context, ListVaultEventsParams) ([]EventInfo, error)
 	WriteVaultEvent(context.Context, WriteVaultEventParams) error
 	RetrieveEvent(context.Context, RetrieveEventParams, io.Writer) (string, error)

--- a/pkg/vaultsprovider/provider.go
+++ b/pkg/vaultsprovider/provider.go
@@ -66,24 +66,24 @@ func (bp *VaultsProvider) CreateVault(ctx context.Context, params app.CreateVaul
 // ListVaults lists all vaults from a given account.
 func (bp *VaultsProvider) ListVaults(
 	ctx context.Context, params app.ListVaultsParams,
-) ([]app.Vault, error) {
+) ([]app.VaultWithCacheDuration, error) {
 	req, err := http.NewRequestWithContext(
-		ctx, http.MethodGet, fmt.Sprintf("%s/vaults/?account=%s", bp.provider, params.Account.Hex()), nil)
+		ctx, http.MethodGet, fmt.Sprintf("%s/v2/vaults/?account=%s", bp.provider, params.Account.Hex()), nil)
 	if err != nil {
-		return []app.Vault{}, fmt.Errorf("could not create request: %s", err)
+		return []app.VaultWithCacheDuration{}, fmt.Errorf("could not create request: %s", err)
 	}
 
 	resp, err := bp.client.Do(req)
 	if err != nil {
-		return []app.Vault{}, fmt.Errorf("request to list vaults failed: %s", err)
+		return []app.VaultWithCacheDuration{}, fmt.Errorf("request to list vaults failed: %s", err)
 	}
 	defer func() {
 		_ = resp.Body.Close()
 	}()
 
-	var vaults []app.Vault
+	var vaults []app.VaultWithCacheDuration
 	if err := json.NewDecoder(resp.Body).Decode(&vaults); err != nil {
-		return []app.Vault{}, fmt.Errorf("failed to read response: %s", err)
+		return []app.VaultWithCacheDuration{}, fmt.Errorf("failed to read response: %s", err)
 	}
 	return vaults, nil
 }


### PR DESCRIPTION
# Summary

This PR changes the `list` command to use the `/v2/vaults` endpoint and return the cache duration together with vault's name.

Goes together with https://github.com/tablelandnetwork/basin-provider/pull/31 and solves [ENG-761](https://linear.app/tableland/issue/ENG-761/add-the-cache-value-as-part-of-the-data-being-listed)

